### PR TITLE
H5P Improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,13 +21,6 @@ module.exports = {
                 sourceType: "script",
             },
         },
-        {
-            files: ["frontend/**/*.{ts,vue,html}"],
-            rules: {
-                "indent": ["error", 2, { "SwitchCase": 1, "ObjectExpression": "first", "ArrayExpression": "first", "MemberExpression": "off", "ignoredNodes": ["ClassBody.body > PropertyDefinition[decorators.length > 0] > .key"] }],
-                "@typescript-eslint/indent": ["error", 2, { "SwitchCase": 1, "ObjectExpression": "first", "ArrayExpression": "first", "MemberExpression": "off" }],
-            }
-        }
     ],
     parserOptions: {
         ecmaVersion: "latest",
@@ -37,6 +30,7 @@ module.exports = {
     plugins: ["@typescript-eslint", "vue", "jsdoc"],
     rules: {
         "indent": "off",
+        "@typescript-eslint/indent": "off",
         "no-duplicate-imports": "warn",
         "no-self-compare": "warn",
         "no-unmodified-loop-condition": "warn",
@@ -52,7 +46,6 @@ module.exports = {
         "block-spacing": "error",
         "@typescript-eslint/brace-style": ["error", "1tbs", { "allowSingleLine": true }],
         "comma-spacing": ["error", { "before": false, "after": true }],
-        "@typescript-eslint/indent": ["error", 4, { "SwitchCase": 1, "ObjectExpression": "first", "ArrayExpression": "first", "MemberExpression": "off", "ignoredNodes": ["ClassBody.body > PropertyDefinition[decorators.length > 0] > .key", "TSTypeParameterInstantiation"] }],
         "no-trailing-spaces": ["warn", {"skipBlankLines": true, "ignoreComments": true}],
         "@typescript-eslint/explicit-function-return-type": "error",
         semi: ["warn", "always"],

--- a/backend/DatabaseServer.ts
+++ b/backend/DatabaseServer.ts
@@ -8,6 +8,7 @@ import { DBH5PFile } from '../model/h5p/DBH5PFile';
 import { DBH5PContent, DBH5PContentUsedBy } from '../model/h5p/DBH5PContent';
 import { DBH5PLibrary } from '../model/h5p/DBH5PLibrary';
 import { DBConfigEntry } from '../model/configuration/DBConfigEntry';
+import { H5PReusability1691157808340 } from './db_migrations/1691157808340-H5P-Reusability';
 
 /**
  * Handles database connection for the backend server.
@@ -37,6 +38,7 @@ export class DatabaseServer {
                 DBH5PContentUsedBy,
                 DBConfigEntry,
             ],
+            migrations: [H5PReusability1691157808340],
         });
 
         console.log(`Loaded database file: ${database}`);
@@ -58,8 +60,18 @@ export class DatabaseServer {
      */
     public async initialize(): Promise<void> {
         await this.db.initialize();
-        await this.db.synchronize();
         console.log('Database connection established.');
+
+        const migrations = await this.db.runMigrations();
+        if (migrations.length > 0) {
+            console.log(
+                `Successfully ran ${migrations.length} migrations: ${migrations
+                    .map((migration) => migration.name)
+                    .join(', ')}`
+            );
+        }
+
+        await this.db.synchronize();
     }
 
     /**

--- a/backend/DatabaseServer.ts
+++ b/backend/DatabaseServer.ts
@@ -5,7 +5,7 @@ import { DBUser } from '../model/user/DBUser';
 import 'reflect-metadata';
 import 'dotenv/config';
 import { DBH5PFile } from '../model/h5p/DBH5PFile';
-import { DBH5PContent } from '../model/h5p/DBH5PContent';
+import { DBH5PContent, DBH5PContentUsedBy } from '../model/h5p/DBH5PContent';
 import { DBH5PLibrary } from '../model/h5p/DBH5PLibrary';
 import { DBConfigEntry } from '../model/configuration/DBConfigEntry';
 
@@ -34,6 +34,7 @@ export class DatabaseServer {
                 DBH5PFile,
                 DBH5PContent,
                 DBH5PLibrary,
+                DBH5PContentUsedBy,
                 DBConfigEntry,
             ],
         });

--- a/backend/controller/AccountController.ts
+++ b/backend/controller/AccountController.ts
@@ -202,7 +202,7 @@ export class AccountController {
         //Removing sequences through SequenceController
         const sequences = await DBSequence.find({ where: { authorId: id } });
         for (const s of sequences) {
-            await SequenceController.deleteSequence(s.code);
+            await SequenceController.deleteSequence(s.code, id);
         }
         // Removing user from the read/write access list in shared sequences
         for (const code of user.sharedSequencesReadAccess) {

--- a/backend/controller/ConfigController.ts
+++ b/backend/controller/ConfigController.ts
@@ -104,6 +104,7 @@ export class ConfigController {
             [ConfigKey.REGISTRATION_TYPE, RegistrationType.CLOSED as unknown],
             [ConfigKey.REGISTRATION_CODES, ''],
             [ConfigKey.REGISTRATION_CODES_EXPIRES_AFTER_USE, true],
+            [ConfigKey.AUTODELETE_UNUSED_H5P, false],
         ]);
         for (const [key, value] of defaultValueMap) {
             const entry = await DBConfigEntry.findOneBy({ key: key });

--- a/backend/controller/SequenceController.ts
+++ b/backend/controller/SequenceController.ts
@@ -553,6 +553,9 @@ export class SequenceController {
             const contentId = entryToRemove.h5pContentId;
             await entryToRemove.remove();
             if (
+                (await ConfigController.getConfigEntry(
+                    ConfigKey.AUTODELETE_UNUSED_H5P
+                )) &&
                 (
                     await DBH5PContentUsedBy.findBy({
                         h5pContentId: contentId,

--- a/backend/controller/SequenceController.ts
+++ b/backend/controller/SequenceController.ts
@@ -448,8 +448,7 @@ export class SequenceController {
             for (const slot in slide.content) {
                 if (slide.content[slot].contentType === ContentType.H5P) {
                     h5pIds.push(
-                        (slide.content[slot].contentType as H5PContent)
-                            .h5pContentId
+                        (slide.content[slot] as H5PContent).h5pContentId
                     );
                 }
             }
@@ -487,7 +486,7 @@ export class SequenceController {
         for (const h5pId of h5pIds) {
             if (
                 usedByEntries.find((entry) => entry.h5pContentId === h5pId) ===
-                null
+                undefined
             ) {
                 // We need to create a new entry
                 const newEntry = new DBH5PContentUsedBy();

--- a/backend/db_migrations/1691157808340-H5P-Reusability.ts
+++ b/backend/db_migrations/1691157808340-H5P-Reusability.ts
@@ -1,0 +1,110 @@
+import { MigrationInterface, QueryRunner, Table, TableColumn } from 'typeorm';
+
+/**
+ * Migration for adding required tables and columns for H5P content reusability.
+ */
+export class H5PReusability1691157808340 implements MigrationInterface {
+    /**
+     * Applies this migration.
+     * @param queryRunner QueryRunner to run this migration with
+     */
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'dbh5_p_content',
+            new TableColumn({
+                name: 'owner',
+                type: 'int',
+                isNullable: true,
+            })
+        );
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'dbh5_p_content_used_by',
+                columns: [
+                    {
+                        name: 'h5pContentId',
+                        type: 'string',
+                        isPrimary: true,
+                    },
+                    {
+                        name: 'sequenceCode',
+                        type: 'string',
+                        isPrimary: true,
+                    },
+                ],
+            })
+        );
+
+        // Assign owners & add usage entries
+        const contents = await queryRunner.query(
+            'SELECT ownerSequence, h5pContentId FROM dbh5_p_content'
+        );
+        for (const content of contents) {
+            const sequence = await queryRunner.query(
+                `SELECT authorId FROM db_sequence WHERE code = '${content.ownerSequence}'`
+            );
+            await queryRunner.query(
+                `INSERT INTO dbh5_p_content_used_by (h5pContentId, sequenceCode) VALUES ('${content.h5pContentId}', '${content.ownerSequence}')`
+            );
+            await queryRunner.query(
+                `UPDATE dbh5_p_content SET owner = '${sequence[0].authorId}' WHERE h5pContentId = '${content.h5pContentId}'`
+            );
+        }
+
+        // Remove "NOT NULL" constraint
+        await queryRunner.changeColumn(
+            'dbh5_p_content',
+            'owner',
+            new TableColumn({
+                name: 'owner',
+                type: 'int',
+            })
+        );
+        await queryRunner.dropColumn('dbh5_p_content', 'ownerSequence');
+    }
+
+    /**
+     * Reverts this migration.
+     * @param queryRunner QueryRunner to run this migration with
+     */
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            'dbh5_p_content',
+            new TableColumn({
+                name: 'ownerSequence',
+                type: 'string',
+                isNullable: true,
+            })
+        );
+
+        // Update DBH5PContent owners
+        const contents = await queryRunner.query(
+            'SELECT h5pContentId FROM dbh5_p_content'
+        );
+        for (const content of contents) {
+            const sequence = await queryRunner.query(
+                `SELECT sequenceCode FROM dbh5_p_content_used_by WHERE h5pContentId = '${content.h5pContentId}'`
+            );
+            if (sequence.length <= 0) {
+                throw new Error('Unused H5P content cannot be migrated');
+            }
+            await queryRunner.query(
+                `UPDATE dbh5_p_content SET ownerSequence = '${sequence[0].sequenceCode}' WHERE h5pContentId = '${content.h5pContentId}'`
+            );
+        }
+
+        // Remove "NOT NULL" constraint
+        await queryRunner.changeColumn(
+            'dbh5_p_content',
+            'ownerSequence',
+            new TableColumn({
+                name: 'ownerSequence',
+                type: 'string',
+            })
+        );
+
+        await queryRunner.dropTable('dbh5_p_content_used_by');
+        await queryRunner.dropColumn('dbh5_p_content', 'owner');
+    }
+}

--- a/backend/h5p/H5PContentStorage.ts
+++ b/backend/h5p/H5PContentStorage.ts
@@ -5,21 +5,14 @@ import {
     IContentStorage,
     IFileStats,
     ILibraryName,
-    IUser,
     LibraryName,
-    Permission,
 } from '@lumieducation/h5p-server';
 import { Readable } from 'stream';
 import { DBH5PFile } from '../../model/h5p/DBH5PFile';
 import { DBH5PContent } from '../../model/h5p/DBH5PContent';
-import { DBUser } from '../../model/user/DBUser';
 import { DBSequence } from '../../model/sequence/DBSequence';
-import { UserClass } from '../../model/user/IUser';
-import {
-    LoernwerkError,
-    LoernwerkErrorCodes,
-} from '../../model/loernwerkError';
 import { In } from 'typeorm';
+import { H5PUser } from './H5PPermissionSystem';
 
 /**
  * Custom H5P Content storage implementation to use the SQL database.
@@ -39,7 +32,7 @@ export class H5PContentStorage implements IContentStorage {
     public async addContent(
         metadata: IContentMetadata,
         content: unknown,
-        user: IUser,
+        user: H5PUser,
         contentId?: ContentId
     ): Promise<ContentId> {
         const dbContent = new DBH5PContent();
@@ -64,21 +57,12 @@ export class H5PContentStorage implements IContentStorage {
      * @param filename The filename; can be a path including subdirectories
      * (e.g. 'images/xyz.png')
      * @param readStream A readable stream that contains the data
-     * @param user (optional) The user who owns this object
      */
     public async addFile(
         contentId: ContentId,
         filename: string,
-        readStream: Readable,
-        user?: IUser
+        readStream: Readable
     ): Promise<void> {
-        if (user && !(await this.canUserAccessContent(user.id, contentId))) {
-            throw new LoernwerkError(
-                'User is not allowed to edit this content',
-                LoernwerkErrorCodes.FORBIDDEN
-            );
-        }
-
         // Converting the readable to a string
         const chunks = [];
         for await (const chunk of readStream) {
@@ -130,22 +114,8 @@ export class H5PContentStorage implements IContentStorage {
      * Deletes a content object and all its dependent files from the repository.
      * Throws errors if something goes wrong.
      * @param contentId The content id to delete.
-     * @param user The user who wants to delete the content
      */
-    public async deleteContent(
-        contentId: ContentId,
-        user?: IUser
-    ): Promise<void> {
-        if (
-            user &&
-            !(await this.canUserAccessContent(user.id, contentId, true))
-        ) {
-            throw new LoernwerkError(
-                'User is not allowed to edit this content',
-                LoernwerkErrorCodes.FORBIDDEN
-            );
-        }
-
+    public async deleteContent(contentId: ContentId): Promise<void> {
         await DBH5PContent.delete({ h5pContentId: contentId });
         await DBH5PFile.delete({ ownerType: 'content', owner: contentId });
     }
@@ -155,23 +125,11 @@ export class H5PContentStorage implements IContentStorage {
      * @param contentId the content object the file is attached to
      * @param filename the file to delete; can be a path including
      * subdirectories (e.g. 'images/xyz.png')
-     * @param user The user who wants to delete the file
      */
     public async deleteFile(
         contentId: ContentId,
-        filename: string,
-        user?: IUser
+        filename: string
     ): Promise<void> {
-        if (
-            user &&
-            !(await this.canUserAccessContent(user.id, contentId, true))
-        ) {
-            throw new LoernwerkError(
-                'User is not allowed to edit this content',
-                LoernwerkErrorCodes.FORBIDDEN
-            );
-        }
-
         await DBH5PFile.delete({
             ownerType: 'content',
             owner: contentId,
@@ -184,22 +142,13 @@ export class H5PContentStorage implements IContentStorage {
      * piece of content.
      * @param contentId the id of the content object that the file is attached to
      * @param filename the filename of the file to get information about
-     * @param user the user who wants to retrieve the content file
      * @returns FileStats of the requested file
      */
     public async getFileStats(
         contentId: ContentId,
-        filename: string,
-        user: IUser
+        filename: string
     ): Promise<IFileStats> {
-        if (!(await this.canUserAccessContent(user.id, contentId, true))) {
-            throw new LoernwerkError(
-                'User is not allowed to edit this content',
-                LoernwerkErrorCodes.FORBIDDEN
-            );
-        }
-
-        return await DBH5PFile.findOne({
+        return await DBH5PFile.findOneOrFail({
             select: { birthtime: true, size: true },
             where: {
                 ownerType: 'content',
@@ -225,35 +174,28 @@ export class H5PContentStorage implements IContentStorage {
     public async getFileStream(
         contentId: ContentId,
         filename: string,
-        user: IUser,
+        user: H5PUser,
         rangeStart?: number,
         rangeEnd?: number
     ): Promise<Readable> {
-        const file = await DBH5PFile.findOneBy({
+        const file = await DBH5PFile.findOneByOrFail({
             ownerType: 'content',
             owner: contentId,
             filename: filename,
         });
         const buffer = Buffer.from(file.content);
-        const bufferStart = rangeStart | 0;
-        const bufferEnd = rangeEnd | buffer.length;
+        const bufferStart = rangeStart || 0;
+        const bufferEnd = rangeEnd || buffer.length;
         return Readable.from(buffer.subarray(bufferStart, bufferEnd));
     }
 
     /**
      * Returns the content metadata (=h5p.json) for a content id
      * @param contentId the content id for which to retrieve the metadata
-     * @param user (optional) the user who wants to access the metadata. If
-     * undefined, access must be granted.
      * @returns the metadata
      */
-    public async getMetadata(
-        contentId: ContentId,
-        user?: IUser
-    ): Promise<IContentMetadata> {
-        // Since anyone is allowed to view H5P Content, we dont need to check user permissions here
-        void user;
-        const content = await DBH5PContent.findOne({
+    public async getMetadata(contentId: ContentId): Promise<IContentMetadata> {
+        const content = await DBH5PContent.findOneOrFail({
             where: { h5pContentId: contentId },
         });
 
@@ -270,16 +212,11 @@ export class H5PContentStorage implements IContentStorage {
     /**
      * Returns the content object (=content.json) for a content id
      * @param contentId the content id for which to retrieve the metadata
-     * @param user (optional) the user who wants to access the metadata. If
-     * undefined, access must be granted.
      * @returns the content object
      */
     public async getParameters(
-        contentId: ContentId,
-        user?: IUser
+        contentId: ContentId
     ): Promise<ContentParameters> {
-        // Since anyone is allowed to view H5P Content, we dont need to check user permissions here
-        void user;
         const content = await DBH5PContent.findOneBy({
             h5pContentId: contentId,
         });
@@ -327,63 +264,16 @@ export class H5PContentStorage implements IContentStorage {
     }
 
     /**
-     * Returns an array of permissions that the user has on the piece of content
-     * @param contentId the content id to check
-     * @param user the user who wants to access the piece of content
-     * @returns the permissions the user has for this content (e.g. download it,
-     * delete it etc.)
-     */
-    public async getUserPermissions(
-        contentId: ContentId,
-        user: IUser
-    ): Promise<Permission[]> {
-        const allowedPermissions = [Permission.View];
-
-        const content = await DBH5PContent.findOne({
-            where: { h5pContentId: contentId },
-            select: { ownerSequence: true },
-        });
-        if (!content || content.ownerSequence === null) {
-            return allowedPermissions;
-        }
-        const dbUser = await DBUser.findOneByOrFail({ id: parseInt(user.id) });
-        if (dbUser.type === UserClass.ADMIN) {
-            allowedPermissions.push(
-                Permission.Edit,
-                Permission.Delete,
-                Permission.List
-            );
-        }
-
-        const sequence = await DBSequence.findOneByOrFail({
-            code: content.ownerSequence,
-        });
-        if (
-            sequence.authorId === dbUser.id ||
-            sequence.readAccess.includes(dbUser.id) ||
-            sequence.writeAccess.includes(dbUser.id)
-        ) {
-            allowedPermissions.push(
-                Permission.Edit,
-                Permission.Delete,
-                Permission.List
-            );
-        }
-
-        return allowedPermissions;
-    }
-
-    /**
      * Lists the content objects in the system (if no user is specified) or
      * owned by the user.
      * @param user (optional) the user who owns the content
      * @returns a list of contentIds
      */
-    public async listContent(user?: IUser): Promise<ContentId[]> {
+    public async listContent(user?: H5PUser): Promise<ContentId[]> {
         // Since content isn't owned by individual users here, all we can check is content used by sequences owned by a single user
         if (user) {
             const sequences = await DBSequence.find({
-                where: { authorId: parseInt(user.id) },
+                where: { authorId: user.userId },
                 select: { code: true },
             });
             const sequenceCodes = sequences.map((sequence) => sequence.code);
@@ -404,55 +294,14 @@ export class H5PContentStorage implements IContentStorage {
      * Gets the filenames of files added to the content with addFile(...) (e.g.
      * images, videos or other files)
      * @param contentId the piece of content
-     * @param user the user who wants to access the piece of content
      * @returns a list of files that are used in the piece of content, e.g.
      * ['images/image1.png', 'videos/video2.mp4', 'file.xyz']
      */
-    public async listFiles(
-        contentId: ContentId,
-        user: IUser
-    ): Promise<string[]> {
-        // Since all users are allowed to view H5P, I dont think access control is needed here
-        void user;
+    public async listFiles(contentId: ContentId): Promise<string[]> {
         const files = await DBH5PFile.find({
             select: { filename: true },
             where: { ownerType: 'content', owner: contentId },
         });
         return files.map((file) => file.filename);
-    }
-
-    /**
-     * Checks whether a user can access specific H5P content, by checking the owner/read-write-permissions/admin privileges.
-     * @param userId User id to check
-     * @param contentId Content id to check
-     * @param adminAllowed Whether admin privilages are also allowed
-     * @returns true, if the user specified by the user id is allowed to access this content
-     * @private
-     */
-    private async canUserAccessContent(
-        userId: string,
-        contentId: string,
-        adminAllowed?: boolean
-    ): Promise<boolean> {
-        const content = await DBH5PContent.findOne({
-            where: { h5pContentId: contentId },
-            select: { ownerSequence: true },
-        });
-        if (!content || content.ownerSequence === null) {
-            return true;
-        }
-        const user = await DBUser.findOneByOrFail({ id: parseInt(userId) });
-        if (adminAllowed && user.type === UserClass.ADMIN) {
-            return true;
-        }
-
-        const sequence = await DBSequence.findOneByOrFail({
-            code: content.ownerSequence,
-        });
-        return (
-            sequence.readAccess.includes(user.id) ||
-            sequence.writeAccess.includes(user.id) ||
-            sequence.authorId === user.id
-        );
     }
 }

--- a/backend/h5p/H5PContentStorage.ts
+++ b/backend/h5p/H5PContentStorage.ts
@@ -45,7 +45,7 @@ export class H5PContentStorage implements IContentStorage {
             } else {
                 if (user.userId === existingContent.owner) {
                     // Owner trying to replace the existing content
-                    this.deleteContent(contentId);
+                    await this.deleteContent(contentId);
                     dbContent.h5pContentId = contentId;
                 }
             }

--- a/backend/h5p/H5PContentStorage.ts
+++ b/backend/h5p/H5PContentStorage.ts
@@ -10,8 +10,6 @@ import {
 import { Readable } from 'stream';
 import { DBH5PFile } from '../../model/h5p/DBH5PFile';
 import { DBH5PContent } from '../../model/h5p/DBH5PContent';
-import { DBSequence } from '../../model/sequence/DBSequence';
-import { In } from 'typeorm';
 import { H5PUser } from './H5PPermissionSystem';
 
 /**
@@ -46,6 +44,7 @@ export class H5PContentStorage implements IContentStorage {
                 dbContent.h5pContentId = contentId;
             }
         }
+        dbContent.owner = user.userId;
         await dbContent.save();
         return dbContent.h5pContentId;
     }
@@ -270,15 +269,9 @@ export class H5PContentStorage implements IContentStorage {
      * @returns a list of contentIds
      */
     public async listContent(user?: H5PUser): Promise<ContentId[]> {
-        // Since content isn't owned by individual users here, all we can check is content used by sequences owned by a single user
         if (user) {
-            const sequences = await DBSequence.find({
-                where: { authorId: user.userId },
-                select: { code: true },
-            });
-            const sequenceCodes = sequences.map((sequence) => sequence.code);
             const ids = await DBH5PContent.find({
-                where: { ownerSequence: In(sequenceCodes) },
+                where: { owner: user.userId },
                 select: { h5pContentId: true },
             });
             return ids.map((content) => content.h5pContentId);

--- a/backend/h5p/H5PPermissionSystem.ts
+++ b/backend/h5p/H5PPermissionSystem.ts
@@ -1,0 +1,98 @@
+import {
+    ContentPermission,
+    GeneralPermission,
+    IPermissionSystem,
+    IUser,
+} from '@lumieducation/h5p-server';
+import { DBH5PContent } from '../../model/h5p/DBH5PContent';
+import { DBSequence } from '../../model/sequence/DBSequence';
+
+export interface H5PUser extends IUser {
+    isAdmin: boolean;
+    isLoggedIn: boolean;
+    userId: number;
+}
+
+/**
+ * Class managing permissions for H5P library
+ */
+export class H5PPermissionSystem implements IPermissionSystem<H5PUser> {
+    /**
+     * Checks content permissions for an user.
+     * @param actingUser User to check
+     * @param permission Permission to check
+     * @param contentId Content id to check
+     * @returns true, if the user is allowed to take the requested action on the supplied content, false otherwise
+     */
+    async checkForContent(
+        actingUser: H5PUser,
+        permission: ContentPermission,
+        contentId: string | undefined
+    ): Promise<boolean> {
+        if (permission === ContentPermission.View) {
+            return true;
+        }
+        if (actingUser.isAdmin) {
+            return true;
+        }
+        if (
+            actingUser.isLoggedIn &&
+            (permission === ContentPermission.Create ||
+                permission === ContentPermission.List)
+        ) {
+            return true;
+        }
+
+        if (!contentId) {
+            return false;
+        }
+        const content = await DBH5PContent.findOne({
+            where: { h5pContentId: contentId },
+            select: ['ownerSequence'],
+        });
+        if (!content || content.ownerSequence === null) {
+            return true;
+        }
+        const sequence = await DBSequence.findOneOrFail({
+            where: { code: content.ownerSequence },
+            select: ['authorId', 'readAccess', 'writeAccess'],
+        });
+        return (
+            sequence.writeAccess.includes(actingUser.userId) ||
+            sequence.authorId === actingUser.userId
+        );
+    }
+
+    /**
+     * Checks permissions regarding user data. Will always return false, since we don't use userdata in this project.
+     * @returns false
+     */
+    async checkForUserData(): Promise<boolean> {
+        return false;
+    }
+
+    /**
+     * Checks whether an user is allowed to interact with temporaray files.
+     * @param actingUser User to check
+     * @returns true, if the user is logged in, false otherwise
+     */
+    async checkForTemporaryFile(actingUser: H5PUser): Promise<boolean> {
+        return actingUser.isLoggedIn;
+    }
+
+    /**
+     * Checks general permissions for an supplied user
+     * @param actingUser User to check
+     * @param permission Permission to check
+     * @returns true, if the supplied user is allowed to take the requested action, false otherwise
+     */
+    async checkForGeneralAction(
+        actingUser: H5PUser,
+        permission: GeneralPermission
+    ): Promise<boolean> {
+        if (permission === GeneralPermission.CreateRestricted) {
+            return actingUser.isAdmin;
+        }
+        return actingUser.isLoggedIn;
+    }
+}

--- a/backend/loernwerkUtilities.ts
+++ b/backend/loernwerkUtilities.ts
@@ -4,6 +4,7 @@ import i18nextFsBackend from 'i18next-fs-backend';
 import i18nextHttpMiddleware from 'i18next-http-middleware';
 import { join } from 'path';
 import { IUser } from '@lumieducation/h5p-server';
+import { H5PUser } from './h5p/H5PPermissionSystem';
 
 /**
  * Express middleware for checking user authentication.
@@ -178,7 +179,7 @@ declare module 'express-session' {
 declare module 'express-serve-static-core' {
     interface Request {
         // User object required by H5P library.
-        user: IUser;
+        user: IUser | H5PUser;
         // Translation function for error messages. Name forced by H5P library.
         t: TFunction;
         // Language used by the user.

--- a/backend/loernwerkUtilities.ts
+++ b/backend/loernwerkUtilities.ts
@@ -3,7 +3,7 @@ import i18next, { TFunction } from 'i18next';
 import i18nextFsBackend from 'i18next-fs-backend';
 import i18nextHttpMiddleware from 'i18next-http-middleware';
 import { join } from 'path';
-import { H5PUser } from './h5p/H5PPermissionSystem';
+import { IUser } from '@lumieducation/h5p-server';
 
 /**
  * Express middleware for checking user authentication.
@@ -178,7 +178,7 @@ declare module 'express-session' {
 declare module 'express-serve-static-core' {
     interface Request {
         // User object required by H5P library.
-        user: H5PUser;
+        user: IUser;
         // Translation function for error messages. Name forced by H5P library.
         t: TFunction;
         // Language used by the user.

--- a/backend/loernwerkUtilities.ts
+++ b/backend/loernwerkUtilities.ts
@@ -1,9 +1,9 @@
 import { NextFunction, Request, Response } from 'express';
-import { IUser } from '@lumieducation/h5p-server';
 import i18next, { TFunction } from 'i18next';
 import i18nextFsBackend from 'i18next-fs-backend';
 import i18nextHttpMiddleware from 'i18next-http-middleware';
 import { join } from 'path';
+import { H5PUser } from './h5p/H5PPermissionSystem';
 
 /**
  * Express middleware for checking user authentication.
@@ -80,22 +80,22 @@ export function buildH5PRequest(
     if (req.session.userId === undefined) {
         req.user = {
             id: 'anonymous',
-            canCreateRestricted: false,
-            canInstallRecommended: true,
-            canUpdateAndInstallLibraries: false,
             email: 'anonymous@loernwerk.de',
             name: 'Anonymous student',
             type: 'local',
+            isAdmin: false,
+            isLoggedIn: false,
+            userId: -1,
         };
     } else {
         req.user = {
             id: req.session.userId?.toString(),
-            canCreateRestricted: true,
-            canInstallRecommended: true,
-            canUpdateAndInstallLibraries: true,
-            email: req.session.email,
-            name: req.session.username,
+            email: req.session.email || '',
+            name: req.session.username || '',
             type: 'local',
+            isAdmin: req.session.isAdmin || false,
+            isLoggedIn: true,
+            userId: req.session.userId,
         };
     }
     if (translationFunction !== null) {
@@ -175,7 +175,7 @@ declare module 'express-session' {
 declare module 'express-serve-static-core' {
     interface Request {
         // User object required by H5P library.
-        user: IUser;
+        user: H5PUser;
         // Translation function for error messages. Name forced by H5P library.
         t: TFunction;
         // Language used by the user.

--- a/backend/loernwerkUtilities.ts
+++ b/backend/loernwerkUtilities.ts
@@ -109,6 +109,9 @@ export function buildH5PRequest(
             }
         >;
     }
+    if (req.query.lang !== undefined) {
+        req.language = req.query.lang as string;
+    }
 
     next();
 }
@@ -153,7 +156,7 @@ export async function buildH5Pi18n(): Promise<void> {
                 'metadata-semantics',
                 'server',
             ],
-            preload: ['de'],
+            preload: ['de', 'en'],
         });
 }
 

--- a/backend/router/H5PRouterFactory.ts
+++ b/backend/router/H5PRouterFactory.ts
@@ -24,7 +24,7 @@ export class H5PRouterFactory extends RouterFactory {
         h5pRouter.put(
             '/',
             requireLogin,
-            requireBody('params', 'library', 'sequence'),
+            requireBody('params', 'library'),
             buildH5PRequest,
             async (req, res) => {
                 // Deeper checks of request body

--- a/backend/router/H5PRouterFactory.ts
+++ b/backend/router/H5PRouterFactory.ts
@@ -7,7 +7,6 @@ import {
 } from '../loernwerkUtilities';
 import { H5PServer } from '../h5p/H5PServer';
 import { IEditorModel } from '@lumieducation/h5p-server';
-import { DBH5PContent } from '../../model/h5p/DBH5PContent';
 import { H5PUser } from '../h5p/H5PPermissionSystem';
 
 /**
@@ -46,12 +45,6 @@ export class H5PRouterFactory extends RouterFactory {
                             req.body.library,
                             req.user
                         );
-
-                    // Try to update belonging sequence code
-                    await DBH5PContent.update(
-                        { h5pContentId: h5pObject.id },
-                        { ownerSequence: req.body.sequence }
-                    );
 
                     res.json({
                         contentId: h5pObject.id,

--- a/backend/router/H5PRouterFactory.ts
+++ b/backend/router/H5PRouterFactory.ts
@@ -8,6 +8,7 @@ import {
 import { H5PServer } from '../h5p/H5PServer';
 import { IEditorModel } from '@lumieducation/h5p-server';
 import { DBH5PContent } from '../../model/h5p/DBH5PContent';
+import { H5PUser } from '../h5p/H5PPermissionSystem';
 
 /**
  * Builds router for requests regarding H5P management
@@ -143,13 +144,13 @@ export class H5PRouterFactory extends RouterFactory {
                         req.params.contentId,
                         {
                             id: 'anonymous',
-                            canCreateRestricted: false,
-                            canInstallRecommended: false,
-                            canUpdateAndInstallLibraries: false,
                             email: 'anonymous@loernwerk.de',
                             name: 'Anonymous student',
                             type: 'local',
-                        },
+                            isAdmin: false,
+                            isLoggedIn: false,
+                            userId: -1,
+                        } as H5PUser,
                         req.language ?? 'en'
                     );
                 res.json(content);

--- a/backend/router/H5PRouterFactory.ts
+++ b/backend/router/H5PRouterFactory.ts
@@ -8,6 +8,7 @@ import {
 import { H5PServer } from '../h5p/H5PServer';
 import { IEditorModel } from '@lumieducation/h5p-server';
 import { H5PUser } from '../h5p/H5PPermissionSystem';
+import { DBH5PContentUsedBy } from '../../model/h5p/DBH5PContent';
 
 /**
  * Builds router for requests regarding H5P management
@@ -147,6 +148,59 @@ export class H5PRouterFactory extends RouterFactory {
                         req.language ?? 'en'
                     );
                 res.json(content);
+            } catch (e) {
+                res.status(500).send((e as Error).message);
+            }
+        });
+
+        h5pRouter.get('/list', async (req, res) => {
+            let userId = req.session.userId as number;
+            if (req.query.id && req.session.isAdmin) {
+                userId = parseInt(req.query.id as string);
+            }
+
+            const userToQuery: H5PUser = {
+                id: userId.toString(),
+                userId: userId,
+                isAdmin: req.session.isAdmin || false,
+                isLoggedIn: true,
+                email: req.session.email as string,
+                name: req.session.username as string,
+                type: 'local',
+            };
+
+            try {
+                const contents = await H5PServer.getInstance()
+                    .getH5PEditor()
+                    .contentManager.listContent(userToQuery);
+                const result: {
+                    title: string;
+                    contentId: string;
+                    mainLibrary: string;
+                    usedSequences: string[];
+                }[] = [];
+
+                for (const content of contents) {
+                    const metadata = await H5PServer.getInstance()
+                        .getH5PEditor()
+                        .contentManager.getContentMetadata(
+                            content,
+                            userToQuery
+                        );
+                    const usedSequences = await DBH5PContentUsedBy.findBy({
+                        h5pContentId: content,
+                    });
+                    result.push({
+                        title: metadata.title,
+                        contentId: content,
+                        mainLibrary: metadata.mainLibrary,
+                        usedSequences: usedSequences.map(
+                            (sequence) => sequence.sequenceCode
+                        ),
+                    });
+                }
+
+                res.json(result);
             } catch (e) {
                 res.status(500).send((e as Error).message);
             }

--- a/backend/router/SequenceRouterFactory.ts
+++ b/backend/router/SequenceRouterFactory.ts
@@ -55,7 +55,10 @@ export class SequenceRouterFactory extends RouterFactory {
                 }
 
                 try {
-                    await SequenceController.saveSequence(req.body);
+                    await SequenceController.saveSequence(
+                        req.body,
+                        req.session.userId as number
+                    );
                     res.sendStatus(204);
                 } catch {
                     res.sendStatus(400);
@@ -86,7 +89,10 @@ export class SequenceRouterFactory extends RouterFactory {
                 }
 
                 try {
-                    await SequenceController.deleteSequence(req.body.code);
+                    await SequenceController.deleteSequence(
+                        req.body.code,
+                        req.session.userId as number
+                    );
                     res.sendStatus(204);
                 } catch {
                     res.sendStatus(400);

--- a/frontend/src/components/admin/ConfigEditor.vue
+++ b/frontend/src/components/admin/ConfigEditor.vue
@@ -86,6 +86,7 @@ const configKeys = [
   ConfigKey.REGISTRATION_TYPE,
   ConfigKey.REGISTRATION_CODES,
   ConfigKey.REGISTRATION_CODES_EXPIRES_AFTER_USE,
+  ConfigKey.AUTODELETE_UNUSED_H5P,
 ];
 
 const disableButton = ref(false);
@@ -121,6 +122,9 @@ const keyDescription: Record<ConfigKey, string> = {
   [ConfigKey.REGISTRATION_CODES]: i18n.global.t('config.registrationCodes'),
   [ConfigKey.REGISTRATION_CODES_EXPIRES_AFTER_USE]: i18n.global.t(
     'config.registrationCodesExpirations'
+  ),
+  [ConfigKey.AUTODELETE_UNUSED_H5P]: i18n.global.t(
+    'config.autodeleteUnusedH5P'
   ),
 };
 

--- a/frontend/src/components/contentDisplay/H5PDisplay.vue
+++ b/frontend/src/components/contentDisplay/H5PDisplay.vue
@@ -5,15 +5,19 @@
         <ContainerComponent class="fixed top-3 bottom-3 left-3 right-3 z-10">
           <InteractableComponent class="w-fit mb-3">
             <select v-model="toEdit" class="text-xl">
-              <option selected value="new">Neuen H5P-Inhalt erstellen</option>
+              <option selected value="new">
+                {{ $t('h5p.createNewContent') }}
+              </option>
               <option
                 v-for="content in reusable"
                 :key="content.contentId"
                 :value="content.contentId"
                 class="text-xl"
               >
-                {{ content.title }} ({{ content.mainLibrary }}, verwendet von
-                {{ content.usedSequences.length }} Sequenzen)
+                {{ content.title }} ({{ content.mainLibrary }},
+                {{
+                  $t('h5p.usedBy', { object: content.usedSequences.length })
+                }})
               </option>
             </select>
           </InteractableComponent>
@@ -36,7 +40,7 @@
             class="max-w-[75%] max-h-[50%] w-auto h-auto"
           />
           <p class="text-center text-base mt-5 text-black">
-            Klicke um den Inhalt zu bearbeiten
+            {{ $t('h5p.clickToEdit') }}
           </p>
         </div>
       </div>

--- a/frontend/src/components/contentDisplay/H5PDisplay.vue
+++ b/frontend/src/components/contentDisplay/H5PDisplay.vue
@@ -19,7 +19,6 @@
           </InteractableComponent>
           <H5PEditor
             :content-id="toEdit"
-            :sequence-code="h5pContent.sequenceCode"
             :key="toEdit"
             @closed="(id) => saveEditor(id)"
           />
@@ -85,12 +84,12 @@ const emits = defineEmits([
 const isEditorOpen = ref(false);
 const toEdit = ref(props.h5pContent.h5pContentId);
 const reusable: Ref<
-{
-  title: string;
-  mainLibrary: string;
-  contentId: string;
-  usedSequences: string[];
-}[]
+  {
+    title: string;
+    mainLibrary: string;
+    contentId: string;
+    usedSequences: string[];
+  }[]
 > = ref([]);
 
 if (props.editMode) {

--- a/frontend/src/components/contentDisplay/H5PDisplay.vue
+++ b/frontend/src/components/contentDisplay/H5PDisplay.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script setup lang="ts">
-import { PropType, Ref, ref } from 'vue';
+import { PropType, Ref, ref, watch } from 'vue';
 import { H5PContent } from '../../../../model/slide/content/H5PContent';
 import H5PEditor from './H5PEditor.vue';
 import H5PPlayer from './H5PPlayer.vue';
@@ -114,12 +114,20 @@ function openEditor(): void {
  * Saves the editor and returns the new content id to the backend
  * @param id ID to return. Is undefined, if the editor was closed without saving.
  */
-function saveEditor(id: string | undefined): void {
+async function saveEditor(id: string | undefined): Promise<void> {
   if (props.editMode) {
     isEditorOpen.value = false;
     if (id !== undefined) {
       emits('editing', id);
     }
+    reusable.value = await H5PRestInterface.getH5PContentList();
   }
 }
+
+watch(
+  () => props.h5pContent,
+  () => {
+    toEdit.value = props.h5pContent.h5pContentId;
+  }
+);
 </script>

--- a/frontend/src/components/contentDisplay/H5PEditor.vue
+++ b/frontend/src/components/contentDisplay/H5PEditor.vue
@@ -25,19 +25,11 @@ import { H5PRestInterface } from '../../restInterfaces/H5PRestInterface';
 import ButtonComponent from '../ButtonComponent.vue';
 import ContainerComponent from '../ContainerComponent.vue';
 
-const props = defineProps({
+defineProps({
   /**
    * The h5p content to display
    */
   contentId: {
-    type: String,
-    required: true,
-  },
-
-  /**
-   * Code of sequence it belongs to
-   */
-  sequenceCode: {
     type: String,
     required: true,
   },
@@ -71,10 +63,7 @@ onMounted(() => {
       requestBody: { library: string; params: unknown }
     ): Promise<{ contentId: string; metadata: IContentMetadata }> => {
       if (contentId === undefined || contentId === 'undefined') {
-        return await H5PRestInterface.createH5PContent(
-          props.sequenceCode as string,
-          requestBody
-        );
+        return await H5PRestInterface.createH5PContent(requestBody);
       } else {
         return await H5PRestInterface.editH5PContent(contentId, requestBody);
       }

--- a/frontend/src/components/contentDisplay/H5PEditor.vue
+++ b/frontend/src/components/contentDisplay/H5PEditor.vue
@@ -3,12 +3,15 @@
     <div class="flex flex-col space-y-5">
       <h5p-editor ref="editor" :content-id="contentId" class="grow" />
       <div class="flex items-center">
-        <ButtonComponent class="w-fit" :loading="currentlySaving" @click="save"
-          >Save</ButtonComponent
+        <ButtonComponent
+          class="w-fit"
+          :loading="currentlySaving"
+          @click="save"
+          >{{ $t('save') }}</ButtonComponent
         >
-        <ButtonComponent class="w-fit ml-1" @click="close"
-          >Close</ButtonComponent
-        >
+        <ButtonComponent class="w-fit ml-1" @click="close">{{
+          $t('cancel')
+        }}</ButtonComponent>
       </div>
     </div>
   </ContainerComponent>
@@ -24,6 +27,7 @@ import { onMounted, Ref, ref } from 'vue';
 import { H5PRestInterface } from '../../restInterfaces/H5PRestInterface';
 import ButtonComponent from '../ButtonComponent.vue';
 import ContainerComponent from '../ContainerComponent.vue';
+import { i18n } from '../../i18n';
 
 defineProps({
   /**
@@ -55,7 +59,10 @@ onMounted(() => {
     h5pEditor.loadContentCallback = async (
       contentId: string
     ): Promise<IEditorModel> => {
-      return await H5PRestInterface.getH5PContent(contentId);
+      return await H5PRestInterface.getH5PContent(
+        contentId,
+        i18n.global.locale
+      );
     };
 
     h5pEditor.saveContentCallback = async (

--- a/frontend/src/components/contentDisplay/H5PEditor.vue
+++ b/frontend/src/components/contentDisplay/H5PEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <ContainerComponent class="fixed top-3 bottom-3 left-3 right-3 z-10">
+  <ContainerComponent>
     <div class="flex flex-col space-y-5">
       <h5p-editor ref="editor" :content-id="contentId" class="grow" />
       <div class="flex items-center">

--- a/frontend/src/components/navBar/NavigationBar.vue
+++ b/frontend/src/components/navBar/NavigationBar.vue
@@ -18,6 +18,13 @@
     </NavigationBarItem>
 
     <NavigationBarItem
+      :active="isCurrentView('H5POverview')"
+      targetLink="/h5pOverview"
+    >
+      {{ $t('navBar.h5pOverview') }}
+    </NavigationBarItem>
+
+    <NavigationBarItem
       :active="isCurrentView('Admin')"
       targetLink="/admin"
       v-if="isAdmin"

--- a/frontend/src/factories/H5PContentFactory.ts
+++ b/frontend/src/factories/H5PContentFactory.ts
@@ -14,7 +14,6 @@ export class H5PContentFactory extends AbstractContentFactory {
   public buildContent(json: unknown): H5PContent {
     const h5pContent = new H5PContent();
     h5pContent.h5pContentId = (json as H5PContent).h5pContentId;
-    h5pContent.sequenceCode = (json as H5PContent).sequenceCode;
     return h5pContent;
   }
 }

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -94,6 +94,8 @@ const messages = {
       closed: 'Registrierung durch Admin',
       invite: 'Registrierung durch Einladungscodes',
       config: 'Einstellungen',
+      autodeleteUnusedH5P:
+        'Ungenutze H5P-Inhalte bei Sequenz-Bearbeitung oder -Löschung automatisch löschen',
     },
     navBar: {
       overview: 'Sequenzübersicht',
@@ -201,6 +203,8 @@ const messages = {
       closed: 'Only admins can add new users',
       invite: 'Registration through invitecodes',
       config: 'Settings',
+      autodeleteUnusedH5P:
+        'Delete unused H5P contents upon saving or deleting a sequence',
     },
     navBar: {
       overview: 'Sequenceoverview',

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -99,6 +99,7 @@ const messages = {
       overview: 'Sequenzübersicht',
       admin: 'Admin',
       sequenceEdit: 'Sequenzbearbeitung',
+      h5pOverview: 'H5P-Inhalte',
     },
   },
   en: {
@@ -198,6 +199,7 @@ const messages = {
       overview: 'Sequenceoverview',
       admin: 'Admin',
       sequenceEdit: 'Edit sequence',
+      h5pOverview: 'H5P contents',
     },
   },
 };

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -101,6 +101,13 @@ const messages = {
       sequenceEdit: 'Sequenzbearbeitung',
       h5pOverview: 'H5P-Inhalte',
     },
+    h5p: {
+      clickToEdit: 'Klicke um den Inhalt zu bearbeiten',
+      createNewContent: 'Neuen H5P-Inhalt erstellen',
+      usedBy: 'verwendet von {object} Sequenzen',
+      overviewTitle: 'Erstellter H5P-Inhalt',
+      usedSequences: 'Verwendete Sequenzen',
+    },
   },
   en: {
     search: 'Search',
@@ -200,6 +207,13 @@ const messages = {
       admin: 'Admin',
       sequenceEdit: 'Edit sequence',
       h5pOverview: 'H5P contents',
+    },
+    h5p: {
+      clickToEdit: 'Click to edit the content',
+      createNewContent: 'Create new H5P-Content',
+      usedBy: 'used by {object} sequences',
+      overviewTitle: 'Created H5P-Content',
+      usedSequences: 'Used Sequences',
     },
   },
 };

--- a/frontend/src/restInterfaces/H5PRestInterface.ts
+++ b/frontend/src/restInterfaces/H5PRestInterface.ts
@@ -5,6 +5,13 @@ import {
   IPlayerModel,
 } from '@lumieducation/h5p-server';
 
+interface H5POverviewItem {
+  title: string;
+  mainLibrary: string;
+  contentId: string;
+  usedSequences: string[];
+}
+
 /**
  * Implements communication with the Server concerning all H5P-requests
  */
@@ -65,5 +72,22 @@ export class H5PRestInterface extends BaseRestInterface {
     contentId: string
   ): Promise<IPlayerModel> {
     return await this.get<IPlayerModel>(`${this.h5p_path}${contentId}/view`);
+  }
+
+  /**
+   * Sends a request to get a list of all H5P content of the current user
+   * @param userId Optional user to query for
+   * @returns List of all h5p contents of the supplied user
+   */
+  public static async getH5PContentList(
+    userId?: string
+  ): Promise<H5POverviewItem[]> {
+    if (userId) {
+      return await this.get<H5POverviewItem[]>(
+        `${this.h5p_path}list?id=${userId}`
+      );
+    } else {
+      return await this.get<H5POverviewItem[]>(`${this.h5p_path}list`);
+    }
   }
 }

--- a/frontend/src/restInterfaces/H5PRestInterface.ts
+++ b/frontend/src/restInterfaces/H5PRestInterface.ts
@@ -38,10 +38,16 @@ export class H5PRestInterface extends BaseRestInterface {
   /**
    * Sends a request to backend to get H5P content for editing
    * @param contentId Internal id of the content to edit
+   * @param language Optional language to use
    * @returns H5P content for editing
    */
-  public static async getH5PContent(contentId: string): Promise<IEditorModel> {
-    return await this.get<IEditorModel>(`${this.h5p_path}${contentId}/edit`);
+  public static async getH5PContent(
+    contentId: string,
+    language?: string
+  ): Promise<IEditorModel> {
+    return await this.get<IEditorModel>(
+      `${this.h5p_path}${contentId}/edit?lang=${language}`
+    );
   }
 
   /**

--- a/frontend/src/restInterfaces/H5PRestInterface.ts
+++ b/frontend/src/restInterfaces/H5PRestInterface.ts
@@ -20,19 +20,18 @@ export class H5PRestInterface extends BaseRestInterface {
 
   /**
    * Sends a request to backend to add new H5P content
-   * @param sequenceCode Sequence code of the sequence that this content belongs to
    * @param requestBody Request body supplied by the H5P editor
    * @param requestBody.library Library supplied by the H5P editor
    * @param requestBody.params Content parameters supplied by the H5P editor
    * @returns H5P response by the backend
    */
-  public static async createH5PContent(
-    sequenceCode: string,
-    requestBody: { library: string; params: unknown }
-  ): Promise<{ contentId: string; metadata: IContentMetadata }> {
+  public static async createH5PContent(requestBody: {
+    library: string;
+    params: unknown;
+  }): Promise<{ contentId: string; metadata: IContentMetadata }> {
     return await this.put<{ contentId: string; metadata: IContentMetadata }>(
       this.h5p_path,
-      { ...requestBody, sequence: sequenceCode }
+      { ...requestBody }
     );
   }
 

--- a/frontend/src/restInterfaces/H5PRestInterface.ts
+++ b/frontend/src/restInterfaces/H5PRestInterface.ts
@@ -85,7 +85,7 @@ export class H5PRestInterface extends BaseRestInterface {
    * @returns List of all h5p contents of the supplied user
    */
   public static async getH5PContentList(
-    userId?: string
+    userId?: number
   ): Promise<H5POverviewItem[]> {
     if (userId) {
       return await this.get<H5POverviewItem[]>(

--- a/frontend/src/restInterfaces/H5PRestInterface.ts
+++ b/frontend/src/restInterfaces/H5PRestInterface.ts
@@ -89,4 +89,12 @@ export class H5PRestInterface extends BaseRestInterface {
       return await this.get<H5POverviewItem[]>(`${this.h5p_path}list`);
     }
   }
+
+  /**
+   * Sends a request to delete H5P content.
+   * @param contentId id of the content to delete
+   */
+  public static async deleteH5PContent(contentId: string): Promise<void> {
+    await this.delete(`${this.h5p_path}`, { id: contentId });
+  }
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -7,6 +7,7 @@ import SlideView from '../views/SlideView.vue';
 import FinishedView from '../views/FinishedView.vue';
 import SequenceOverviewView from '../views/SequenceOverviewView.vue';
 import SequenceEditView from '../views/SequenceEditView.vue';
+import H5PContentOverviewView from '../views/H5PContentOverviewView.vue';
 
 const router = createRouter({
   history: createWebHistory(''),
@@ -57,6 +58,12 @@ const router = createRouter({
       component: SequenceEditView,
       meta: { hasNavBar: true, requiresLogin: true },
       props: true,
+    },
+    {
+      path: '/h5pOverview',
+      name: 'H5POverview',
+      component: H5PContentOverviewView,
+      meta: { hasNavBar: true, requiresLogin: true },
     },
   ],
 });

--- a/frontend/src/views/H5PContentOverviewView.vue
+++ b/frontend/src/views/H5PContentOverviewView.vue
@@ -6,7 +6,7 @@
   </div>
 
   <div class="flex flex-col w-full">
-    <div class="underline text-xl">Erstellter H5P-Inhalt:</div>
+    <div class="underline text-xl">{{ $t('h5p.overviewTitle') }}:</div>
 
     <ContainerComponent
       v-for="(content, idx) in contents"
@@ -18,17 +18,18 @@
         <div class="h-full pt-2">{{ content.mainLibrary }}</div>
         <div class="flex-grow pt-2">
           <span v-if="content.usedSequences.length > 0">
-            Verwendete Sequenzen: {{ content.usedSequences.join(', ') }}
+            {{ $t('h5p.usedSequences') }}:
+            {{ content.usedSequences.join(', ') }}
           </span>
         </div>
         <ButtonComponent
           v-if="content.usedSequences.length === 0"
           @click="deleteContent(content.contentId)"
-          >Löschen</ButtonComponent
+          >{{ $t('delete') }}</ButtonComponent
         >
-        <ButtonComponent @click="editContent(content.contentId)"
-          >Bearbeiten</ButtonComponent
-        >
+        <ButtonComponent @click="editContent(content.contentId)">{{
+          $t('edit')
+        }}</ButtonComponent>
       </div>
     </ContainerComponent>
   </div>

--- a/frontend/src/views/H5PContentOverviewView.vue
+++ b/frontend/src/views/H5PContentOverviewView.vue
@@ -6,7 +6,17 @@
   </div>
 
   <div class="flex flex-col w-full">
-    <div class="underline text-xl">{{ $t('h5p.overviewTitle') }}:</div>
+    <div class="flex flex-row w-full mb-5 justify-between">
+      <div class="underline text-xl">{{ $t('h5p.overviewTitle') }}:</div>
+
+      <InteractableComponent v-if="isAdmin">
+        <select v-model="selectedUser" class="w-full">
+          <option v-for="user of allUsers" :key="user.id" :value="user.id">
+            {{ user.name }}
+          </option>
+        </select>
+      </InteractableComponent>
+    </div>
 
     <ContainerComponent
       v-for="(content, idx) in contents"
@@ -36,14 +46,40 @@
 </template>
 
 <script setup lang="ts">
-import { Ref, ref } from 'vue';
+import { Ref, ref, watch } from 'vue';
 import { H5PRestInterface } from '../restInterfaces/H5PRestInterface';
 import ButtonComponent from '../components/ButtonComponent.vue';
 import ContainerComponent from '../components/ContainerComponent.vue';
+import InteractableComponent from '../components/InteractableComponent.vue';
 import H5PEditor from '../components/contentDisplay/H5PEditor.vue';
+import { AccountRestInterface } from '../restInterfaces/AccountRestInterface';
+import { IUser, UserClass } from '../../../model/user/IUser';
 
 const contents = ref(await H5PRestInterface.getH5PContentList());
 const currentlyEditing: Ref<string | null> = ref(null);
+const selectedUser: Ref<number | null> = ref(null);
+const isAdmin = ref(false);
+const allUsers: Ref<Partial<IUser>[]> = ref([]);
+
+const user = await AccountRestInterface.getOwnAccount();
+if (user.type === UserClass.ADMIN) {
+  allUsers.value = await AccountRestInterface.getAccountMetaDataList();
+  selectedUser.value = user.id as number;
+  isAdmin.value = true;
+}
+
+/**
+ * Updates the list of contents for the active user.
+ */
+async function updateList(): Promise<void> {
+  if (selectedUser.value === null) {
+    contents.value = await H5PRestInterface.getH5PContentList();
+  } else {
+    contents.value = await H5PRestInterface.getH5PContentList(
+      selectedUser.value
+    );
+  }
+}
 
 /**
  * Opens supplied H5P content in the integrated editor.
@@ -58,7 +94,7 @@ function editContent(contentId: string): void {
  */
 async function finishEditing(): Promise<void> {
   currentlyEditing.value = null;
-  contents.value = await H5PRestInterface.getH5PContentList();
+  await updateList();
 }
 
 /**
@@ -67,6 +103,10 @@ async function finishEditing(): Promise<void> {
  */
 async function deleteContent(contentId: string): Promise<void> {
   await H5PRestInterface.deleteH5PContent(contentId);
-  contents.value = await H5PRestInterface.getH5PContentList();
+  await updateList();
 }
+
+watch(selectedUser, async () => {
+  await updateList();
+});
 </script>

--- a/frontend/src/views/H5PContentOverviewView.vue
+++ b/frontend/src/views/H5PContentOverviewView.vue
@@ -1,15 +1,44 @@
 <template>
-  <ul>
-    <li v-for="(content, idx) in contents" :key="idx">
-      {{ content.title }} - {{ content.contentId }} -
-      {{ content.mainLibrary }} - {{ content.usedSequences.join(',') }}
-    </li>
-  </ul>
+  <div v-if="currentlyEditing !== null" class="absolute">
+    <ContainerComponent class="fixed top-3 bottom-3 left-3 right-3 z-10">
+      <H5PEditor
+        :content-id="currentlyEditing"
+        @closed="currentlyEditing = null"
+      />
+    </ContainerComponent>
+  </div>
+
+  <div class="flex flex-col w-full">
+    <div class="underline text-xl">Erstellter H5P-Inhalt:</div>
+
+    <ContainerComponent
+      v-for="(content, idx) in contents"
+      :key="idx"
+      class="w-full h-fit"
+    >
+      <div class="flex flex-row space-x-5 h-fit">
+        <h3 class="text-3xl">{{ content.title }}</h3>
+        <div class="h-full pt-2">{{ content.mainLibrary }}</div>
+        <div class="flex-grow pt-2">
+          Verwendete Sequenzen: {{ content.usedSequences.join(', ') }}
+        </div>
+        <ButtonComponent>Löschen</ButtonComponent>
+        <ButtonComponent @click="currentlyEditing = content.contentId"
+          >Bearbeiten</ButtonComponent
+        >
+      </div>
+    </ContainerComponent>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { Ref, ref } from 'vue';
 import { H5PRestInterface } from '../restInterfaces/H5PRestInterface';
+import ButtonComponent from '../components/ButtonComponent.vue';
+import ContainerComponent from '../components/ContainerComponent.vue';
+import H5PEditor from '../components/contentDisplay/H5PEditor.vue';
 
 const contents = ref(await H5PRestInterface.getH5PContentList());
+
+const currentlyEditing: Ref<string | null> = ref(null);
 </script>

--- a/frontend/src/views/H5PContentOverviewView.vue
+++ b/frontend/src/views/H5PContentOverviewView.vue
@@ -1,0 +1,15 @@
+<template>
+  <ul>
+    <li v-for="(content, idx) in contents" :key="idx">
+      {{ content.title }} - {{ content.contentId }} -
+      {{ content.mainLibrary }} - {{ content.usedSequences.join(',') }}
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { H5PRestInterface } from '../restInterfaces/H5PRestInterface';
+
+const contents = ref(await H5PRestInterface.getH5PContentList());
+</script>

--- a/frontend/src/views/H5PContentOverviewView.vue
+++ b/frontend/src/views/H5PContentOverviewView.vue
@@ -1,10 +1,7 @@
 <template>
   <div v-if="currentlyEditing !== null" class="absolute">
     <ContainerComponent class="fixed top-3 bottom-3 left-3 right-3 z-10">
-      <H5PEditor
-        :content-id="currentlyEditing"
-        @closed="currentlyEditing = null"
-      />
+      <H5PEditor :content-id="currentlyEditing" @closed="finishEditing()" />
     </ContainerComponent>
   </div>
 
@@ -20,10 +17,16 @@
         <h3 class="text-3xl">{{ content.title }}</h3>
         <div class="h-full pt-2">{{ content.mainLibrary }}</div>
         <div class="flex-grow pt-2">
-          Verwendete Sequenzen: {{ content.usedSequences.join(', ') }}
+          <span v-if="content.usedSequences.length > 0">
+            Verwendete Sequenzen: {{ content.usedSequences.join(', ') }}
+          </span>
         </div>
-        <ButtonComponent>Löschen</ButtonComponent>
-        <ButtonComponent @click="currentlyEditing = content.contentId"
+        <ButtonComponent
+          v-if="content.usedSequences.length === 0"
+          @click="deleteContent(content.contentId)"
+          >Löschen</ButtonComponent
+        >
+        <ButtonComponent @click="editContent(content.contentId)"
           >Bearbeiten</ButtonComponent
         >
       </div>
@@ -39,6 +42,30 @@ import ContainerComponent from '../components/ContainerComponent.vue';
 import H5PEditor from '../components/contentDisplay/H5PEditor.vue';
 
 const contents = ref(await H5PRestInterface.getH5PContentList());
-
 const currentlyEditing: Ref<string | null> = ref(null);
+
+/**
+ * Opens supplied H5P content in the integrated editor.
+ * @param contentId H5P content to open
+ */
+function editContent(contentId: string): void {
+  currentlyEditing.value = contentId;
+}
+
+/**
+ * Closes the H5P editor and updates the list.
+ */
+async function finishEditing(): Promise<void> {
+  currentlyEditing.value = null;
+  contents.value = await H5PRestInterface.getH5PContentList();
+}
+
+/**
+ * Deletes H5P content.
+ * @param contentId Id of the content to delete
+ */
+async function deleteContent(contentId: string): Promise<void> {
+  await H5PRestInterface.deleteH5PContent(contentId);
+  contents.value = await H5PRestInterface.getH5PContentList();
+}
 </script>

--- a/frontend/src/views/SequenceEditView.vue
+++ b/frontend/src/views/SequenceEditView.vue
@@ -213,7 +213,6 @@ function changeContent(slot: LayoutSlot, contentType: ContentType): void {
       content = new H5PContent();
       content.contentType = ContentType.H5P;
       content.h5pContentId = 'new';
-      content.sequenceCode = props.sequenceCode;
       break;
   }
 

--- a/model/configuration/ConfigKey.ts
+++ b/model/configuration/ConfigKey.ts
@@ -22,4 +22,8 @@ export enum ConfigKey {
      * if the registration codes expire after use or not
      */
     REGISTRATION_CODES_EXPIRES_AFTER_USE = 'registration_codes_expires_after_use',
+    /**
+     * Auto-delete unused H5P-contents
+     */
+    AUTODELETE_UNUSED_H5P = 'autodelete_unused_h5p',
 }

--- a/model/configuration/ConfigTypeMap.ts
+++ b/model/configuration/ConfigTypeMap.ts
@@ -29,6 +29,8 @@ export class ConfigTypeMap {
                 return { type: 'string' };
             case ConfigKey.REGISTRATION_CODES_EXPIRES_AFTER_USE:
                 return { type: 'boolean' };
+            case ConfigKey.AUTODELETE_UNUSED_H5P:
+                return { type: 'boolean' };
             default:
                 throw new LoernwerkError(
                     'Unknown config key',

--- a/model/h5p/DBH5PContent.ts
+++ b/model/h5p/DBH5PContent.ts
@@ -3,7 +3,13 @@ import {
     IContentAuthor,
     IContentChange,
 } from '@lumieducation/h5p-server/build/src/types';
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    PrimaryColumn,
+    PrimaryGeneratedColumn,
+} from 'typeorm';
 
 /**
  * Database object containing custom created H5P content.
@@ -85,6 +91,18 @@ export class DBH5PContent extends BaseEntity implements IContentMetadata {
     @Column({ type: 'simple-json' })
     content: unknown;
 
-    @Column({ nullable: true })
-    ownerSequence: string;
+    @Column()
+    owner: number;
+}
+
+/**
+ * Database entity mapping which H5P contents are used by which sequences
+ */
+@Entity()
+export class DBH5PContentUsedBy extends BaseEntity {
+    @PrimaryColumn()
+    h5pContentId: string;
+
+    @PrimaryColumn()
+    sequenceCode: string;
 }

--- a/model/slide/content/H5PContent.ts
+++ b/model/slide/content/H5PContent.ts
@@ -7,9 +7,6 @@ export class H5PContent extends Content {
     /** Id of H5P content */
     h5pContentId: string;
 
-    /** Code of sequence this content belongs to */
-    sequenceCode: string;
-
     /**
      * @inheritDoc
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
     "name": "loernwerk",
-    "version": "0.0.1dev",
+    "version": "1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "loernwerk",
-            "version": "0.0.1dev",
+            "version": "1.0",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.4.0",
                 "@fortawesome/free-solid-svg-icons": "^6.4.0",
                 "@fortawesome/vue-fontawesome": "^3.0.3",
                 "@lumieducation/h5p-express": "^9.2.2",
-                "@lumieducation/h5p-server": "^9.2.1",
+                "@lumieducation/h5p-server": "^9.3.0",
                 "@lumieducation/h5p-webcomponents": "^9.2.2",
                 "@types/jest": "^29.5.3",
                 "axios": "^1.4.0",
@@ -704,70 +704,6 @@
                 "node": ">=16"
             }
         },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-            "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-            "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-            "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-            "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@esbuild/darwin-x64": {
             "version": "0.17.19",
             "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
@@ -779,278 +715,6 @@
             "optional": true,
             "os": [
                 "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-            "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-            "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-            "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-            "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-            "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-            "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-            "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-            "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-            "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-            "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-            "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-            "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-            "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-            "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-            "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-            "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-            "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
             ],
             "engines": {
                 "node": ">=12"
@@ -1293,12 +957,6 @@
             "engines": {
                 "node": ">= 14"
             }
-        },
-        "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-            "dev": true,
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -1794,9 +1452,9 @@
             }
         },
         "node_modules/@lumieducation/h5p-server": {
-            "version": "9.2.1",
-            "resolved": "https://registry.npmjs.org/@lumieducation/h5p-server/-/h5p-server-9.2.1.tgz",
-            "integrity": "sha512-l7NO93/MaXT1sU49uQ0alMszdpKEkKevXBhsJmgR0Nhf7NQzJ+fP2q5VUyB/j40VbOyvft+auTbuNvbe0bm0yA==",
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/@lumieducation/h5p-server/-/h5p-server-9.3.0.tgz",
+            "integrity": "sha512-AitkPhKrDpTmK20kua6JdiL9fhZOcqK4gXy1rp8P7/ktUClvvxqkZWSrx/uNv8fctEj8yzn0EFb6BcSZDsyuNw==",
             "dependencies": {
                 "ajv": "^8.12.0",
                 "ajv-keywords": "^5.1.0",
@@ -7222,11 +6880,11 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.0",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-            "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.1.tgz",
+            "integrity": "sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.13"
+                "@jridgewell/sourcemap-codec": "^1.4.15"
             },
             "engines": {
                 "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@fortawesome/vue-fontawesome": "^3.0.3",
         "@lumieducation/h5p-express": "^9.2.2",
-        "@lumieducation/h5p-server": "^9.2.1",
+        "@lumieducation/h5p-server": "^9.3.0",
         "@lumieducation/h5p-webcomponents": "^9.2.2",
         "@types/jest": "^29.5.3",
         "axios": "^1.4.0",


### PR DESCRIPTION
This PR adds the ability to re-use H5P contents across multiple sequences, and adds an overview for all created H5P elements. Closes #43.

The only open discussion point is whether or not to delete contents automatically after they aren't used in sequences anymore. Currently, if the content-author e.g. deletes a sequence, all containing H5P contents will be deleted if they aren't used elsewhere. However, this could be undesired, since it might lead to unintended deletion of h5p contents. If they arent deleted automatically however, it might lead to lots of unused contents in the database.

Also, I'd postpone merging this until friday after the meeting