### PR TITLE
Several bugfixes

### DIFF
--- a/backend/controller/SequenceController.ts
+++ b/backend/controller/SequenceController.ts
@@ -580,10 +580,7 @@ export class SequenceController {
             h5pContentId: In(usedH5PIds),
         });
         for (const h5pId of usedH5PIds) {
-            if (
-                usedByEntries.find((entry) => entry.h5pContentId === h5pId) ===
-                undefined
-            ) {
+            if (usedByEntries.some((entry) => entry.h5pContentId === h5pId)) {
                 // We need to create a new entry
                 const newEntry = new DBH5PContentUsedBy();
                 newEntry.h5pContentId = h5pId;

--- a/frontend/src/components/contentDisplay/DesignOptions.ts
+++ b/frontend/src/components/contentDisplay/DesignOptions.ts
@@ -23,3 +23,11 @@ export const fontFamilies = [
   'Brush Script MT',
 ];
 export const defaultFontFamily = 'Arial';
+export const keyboardBindings = {
+  'list autofill': {
+    key: ' ',
+    handler(): boolean {
+      return true;
+    },
+  },
+};

--- a/frontend/src/components/contentDisplay/H5PDisplay.vue
+++ b/frontend/src/components/contentDisplay/H5PDisplay.vue
@@ -106,7 +106,7 @@ if (props.editMode) {
 function openEditor(): void {
   if (props.editMode) {
     isEditorOpen.value = true;
-    emits('editing');
+    emits('editing', null);
   }
 }
 
@@ -117,9 +117,7 @@ function openEditor(): void {
 async function saveEditor(id: string | undefined): Promise<void> {
   if (props.editMode) {
     isEditorOpen.value = false;
-    if (id !== undefined) {
-      emits('editing', id);
-    }
+    emits('editing', id);
     reusable.value = await H5PRestInterface.getH5PContentList();
   }
 }

--- a/frontend/src/components/contentDisplay/H5PDisplay.vue
+++ b/frontend/src/components/contentDisplay/H5PDisplay.vue
@@ -4,7 +4,7 @@
       <div class="absolute" v-if="isEditorOpen">
         <ContainerComponent class="fixed top-3 bottom-3 left-3 right-3 z-10">
           <InteractableComponent class="w-fit mb-3">
-            <select v-model="toEdit" class="text-xl">
+            <select v-model="toEdit" class="text-xl bg-interactable">
               <option selected value="new">
                 {{ $t('h5p.createNewContent') }}
               </option>

--- a/frontend/src/components/contentDisplay/TextDisplay.vue
+++ b/frontend/src/components/contentDisplay/TextDisplay.vue
@@ -9,7 +9,7 @@
 import { PropType, Ref, onMounted, ref, watch } from 'vue';
 import { TextContent } from '../../../../model/slide/content/TextContent';
 import Quill from 'quill';
-import { colors, sizes, fontFamilies } from './DesignOptions';
+import { colors, sizes, fontFamilies, keyboardBindings } from './DesignOptions';
 import { LayoutSlot } from '../../../../model/slide/layout/Layout';
 
 const props = defineProps({
@@ -71,6 +71,9 @@ onMounted(() => {
     modules: {
       toolbar: {
         container: `#q-toolbar-${props.layoutSlot.toString()}`,
+      },
+      keyboard: {
+        bindings: keyboardBindings,
       },
     },
     readOnly: !props.editMode,

--- a/frontend/src/views/SequenceEditView.vue
+++ b/frontend/src/views/SequenceEditView.vue
@@ -52,7 +52,7 @@
 
         <template v-slot:[getTab(2)]>
           <TextOptionsTab
-            :key="selectedSlideIndex"
+            :key="forceRefresh"
             :selected-slot="
               currentEditingSlot != null ? currentEditingSlot : undefined
             "
@@ -61,7 +61,7 @@
       </TabbedContainer>
       <div class="grow flex items-center justify-center relative">
         <SlideDisplayFactory
-          :key="selectedSlideIndex"
+          :key="forceRefresh"
           :slide="selectedSlide"
           :edit-mode="true"
           class="h-full absolute"
@@ -117,6 +117,7 @@ const props = defineProps({
 
 const isSaved = ref(false);
 const disableButton = ref(false);
+const forceRefresh = ref(0);
 
 onMounted(() => {
   window.addEventListener('beforeunload', onUnloadEventListener);
@@ -178,6 +179,7 @@ function updateContent(slot: LayoutSlot, update: unknown): void {
     if (update !== undefined) {
       (selectedSlide.value.content[slot] as H5PContent).h5pContentId =
         update as string;
+      forceRefresh.value++;
     }
   }
 }
@@ -226,6 +228,7 @@ function changeContent(slot: LayoutSlot, contentType: ContentType): void {
  */
 function changeSelectedSlide(index: number): void {
   selectedSlideIndex.value = index;
+  forceRefresh.value++;
   currentEditingSlot.value = null;
   editOptionsTabContainer.value?.selectTab('Seite');
 }

--- a/frontend/src/views/SequenceEditView.vue
+++ b/frontend/src/views/SequenceEditView.vue
@@ -175,11 +175,14 @@ function updateContent(slot: LayoutSlot, update: unknown): void {
   if (selectedSlide.value.content[slot]?.contentType == ContentType.TEXT) {
     (selectedSlide.value.content[slot] as TextContent).delta = update as Delta;
   }
-  if (selectedSlide.value.content[slot]?.contentType == ContentType.H5P) {
+  if (
+    selectedSlide.value.content[slot]?.contentType == ContentType.H5P &&
+    update !== null
+  ) {
+    forceRefresh.value++;
     if (update !== undefined) {
       (selectedSlide.value.content[slot] as H5PContent).h5pContentId =
         update as string;
-      forceRefresh.value++;
     }
   }
 }


### PR DESCRIPTION
This PR collects a couple bugfixes for issues that occured while testing.

These currently include:

- Server crashing when re-saving sequences containing H5P contents
- `- ` being deleted at the start of a line in the text editors because Quill started to do a list
- Dropdown to select H5P-content had white font and white background in dark mode
- The text editor of the H5P-editor was creating toolbars for our existing text-contents in a slide (See screenshot). To avoid this, the only fix/workaround so far I've found was to force a re-render of the slide after editing h5p content
<img width="1631" alt="Bildschirmfoto 2023-08-07 um 01 15 26" src="https://github.com/loernwerk/loernwerk/assets/24574219/c6c5fa0e-b90a-45a7-a97b-eb1010bb9172">